### PR TITLE
Upgrade to rustc 1.6.0-nightly (abfadfeee 2015-12-02)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ use super::{
     Unalign, bitcast,
 };
 use std::mem;
-use std::ops::{Not, Neg, Add, Sub, Mul, Div, BitAnd, BitOr, BitXor, Shl, Shr};
+use std::ops;
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
@@ -263,7 +263,7 @@ macro_rules! bool_impls {
                 }
                 )*
         }
-          impl Not for $name {
+          impl ops::Not for $name {
               type Output = Self;
 
               #[inline]
@@ -407,7 +407,7 @@ impl u8x16 {
 
 macro_rules! neg_impls {
     ($zero: expr, $($ty: ident,)*) => {
-        $(impl Neg for $ty {
+        $(impl ops::Neg for $ty {
             type Output = Self;
             fn neg(self) -> Self {
                 $ty::splat($zero) - self
@@ -427,7 +427,7 @@ neg_impls! {
 }
 macro_rules! not_impls {
     ($($ty: ident,)*) => {
-        $(impl Not for $ty {
+        $(impl ops::Not for $ty {
             type Output = Self;
             fn not(self) -> Self {
                 $ty::splat(!0) ^ self
@@ -447,7 +447,7 @@ not_impls! {
 macro_rules! operators {
     ($($trayt: ident ($func: ident, $method: ident): $($ty: ty),*;)*) => {
         $(
-            $(impl $trayt for $ty {
+            $(impl ops::$trayt for $ty {
                 type Output = Self;
                 #[inline]
                 fn $method(self, x: Self) -> Self {
@@ -486,14 +486,14 @@ operators! {
 macro_rules! shift_one {
     ($ty: ident, $($by: ident),*) => {
         $(
-        impl Shl<$by> for $ty {
+        impl ops::Shl<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shl(self, other: $by) -> Self {
                 unsafe { simd_shl(self, $ty::splat(other as <$ty as Simd>::Elem)) }
             }
         }
-        impl Shr<$by> for $ty {
+        impl ops::Shr<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shr(self, other: $by) -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,8 @@ use super::{
 
     Unalign, bitcast,
 };
+use std::mem;
+use std::ops::{Not, Neg, Add, Sub, Mul, Div, BitAnd, BitOr, BitXor, Shl, Shr};
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
@@ -161,11 +163,11 @@ macro_rules! bool_impls {
         $(impl $name {
             #[inline]
             fn to_repr(self) -> $repr {
-                unsafe {std::mem::transmute(self)}
+                unsafe {mem::transmute(self)}
             }
             #[inline]
             fn from_repr(x: $repr) -> Self {
-                unsafe {std::mem::transmute(x)}
+                unsafe {mem::transmute(x)}
             }
 
             /// Create a new instance.
@@ -261,7 +263,7 @@ macro_rules! bool_impls {
                 }
                 )*
         }
-          impl std::ops::Not for $name {
+          impl Not for $name {
               type Output = Self;
 
               #[inline]
@@ -405,7 +407,7 @@ impl u8x16 {
 
 macro_rules! neg_impls {
     ($zero: expr, $($ty: ident,)*) => {
-        $(impl std::ops::Neg for $ty {
+        $(impl Neg for $ty {
             type Output = Self;
             fn neg(self) -> Self {
                 $ty::splat($zero) - self
@@ -425,7 +427,7 @@ neg_impls! {
 }
 macro_rules! not_impls {
     ($($ty: ident,)*) => {
-        $(impl std::ops::Not for $ty {
+        $(impl Not for $ty {
             type Output = Self;
             fn not(self) -> Self {
                 $ty::splat(!0) ^ self
@@ -445,7 +447,7 @@ not_impls! {
 macro_rules! operators {
     ($($trayt: ident ($func: ident, $method: ident): $($ty: ty),*;)*) => {
         $(
-            $(impl std::ops::$trayt for $ty {
+            $(impl $trayt for $ty {
                 type Output = Self;
                 #[inline]
                 fn $method(self, x: Self) -> Self {
@@ -484,14 +486,14 @@ operators! {
 macro_rules! shift_one {
     ($ty: ident, $($by: ident),*) => {
         $(
-        impl std::ops::Shl<$by> for $ty {
+        impl Shl<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shl(self, other: $by) -> Self {
                 unsafe { simd_shl(self, $ty::splat(other as <$ty as Simd>::Elem)) }
             }
         }
-        impl std::ops::Shr<$by> for $ty {
+        impl Shr<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shr(self, other: $by) -> Self {

--- a/src/sixty_four.rs
+++ b/src/sixty_four.rs
@@ -11,6 +11,8 @@ use super::{
 
     Unalign, bitcast,
 };
+use std::mem;
+use std::ops::{Not, Neg, Add, Sub, Mul, Div, BitAnd, BitOr, BitXor, Shl, Shr};
 
 /// Boolean type for 64-bit integers.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -141,7 +143,7 @@ neg_impls! {
 }
 macro_rules! not_impls {
     ($($ty: ident,)*) => {
-        $(impl std::ops::Not for $ty {
+        $(impl Not for $ty {
             type Output = Self;
             fn not(self) -> Self {
                 $ty::splat(!0) ^ self
@@ -157,7 +159,7 @@ not_impls! {
 macro_rules! operators {
     ($($trayt: ident ($func: ident, $method: ident): $($ty: ty),*;)*) => {
         $(
-            $(impl std::ops::$trayt for $ty {
+            $(impl $trayt for $ty {
                 type Output = Self;
                 #[inline]
                 fn $method(self, x: Self) -> Self {
@@ -193,17 +195,16 @@ operators! {
         bool64fx2;
 }
 
-macro_rules! shift_one {
-    ($ty: ident, $($by: ident),*) => {
+macro_rules! shift_one { ($ty: ident, $($by: ident),*) => {
         $(
-        impl std::ops::Shl<$by> for $ty {
+        impl Shl<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shl(self, other: $by) -> Self {
                 unsafe { simd_shl(self, $ty::splat(other as <$ty as Simd>::Elem)) }
             }
         }
-        impl std::ops::Shr<$by> for $ty {
+        impl Shr<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shr(self, other: $by) -> Self {

--- a/src/sixty_four.rs
+++ b/src/sixty_four.rs
@@ -12,7 +12,7 @@ use super::{
     Unalign, bitcast,
 };
 use std::mem;
-use std::ops::{Not, Neg, Add, Sub, Mul, Div, BitAnd, BitOr, BitXor, Shl, Shr};
+use std::ops;
 
 /// Boolean type for 64-bit integers.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -143,7 +143,7 @@ neg_impls! {
 }
 macro_rules! not_impls {
     ($($ty: ident,)*) => {
-        $(impl Not for $ty {
+        $(impl ops::Not for $ty {
             type Output = Self;
             fn not(self) -> Self {
                 $ty::splat(!0) ^ self
@@ -159,7 +159,7 @@ not_impls! {
 macro_rules! operators {
     ($($trayt: ident ($func: ident, $method: ident): $($ty: ty),*;)*) => {
         $(
-            $(impl $trayt for $ty {
+            $(impl ops::$trayt for $ty {
                 type Output = Self;
                 #[inline]
                 fn $method(self, x: Self) -> Self {
@@ -197,14 +197,14 @@ operators! {
 
 macro_rules! shift_one { ($ty: ident, $($by: ident),*) => {
         $(
-        impl Shl<$by> for $ty {
+        impl ops::Shl<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shl(self, other: $by) -> Self {
                 unsafe { simd_shl(self, $ty::splat(other as <$ty as Simd>::Elem)) }
             }
         }
-        impl Shr<$by> for $ty {
+        impl ops::Shr<$by> for $ty {
             type Output = Self;
             #[inline]
             fn shr(self, other: $by) -> Self {


### PR DESCRIPTION
There seems to be another issue with the recent 1.6 rust versions.

All errors are variations of this, but there are plenty of them so please refer to the Travis log for more details:

```
/home/travis/.cargo/git/checkouts/simd-c969d6c7ccadf1f0/master/src/common.rs:164:25: 164:44 error: failed to resolve. Use of undeclared type or module `std::mem` [E0433]

/home/travis/.cargo/git/checkouts/simd-c969d6c7ccadf1f0/master/src/common.rs:164                 unsafe {std::mem::transmute(self)}
```

https://travis-ci.org/liebharc/basic_dsp/builds/94808621

I'm using Rust version:

```
1.6.0-nightly (abfadfeee 2015-12-02)
```
