### PR TITLE
Implement operations on 256-bit vectors (float, integer, bool) and some AVX specific functions

### DIFF
--- a/benches/mandelbrot.rs
+++ b/benches/mandelbrot.rs
@@ -50,7 +50,7 @@ fn simd4(c_x: f32x4, c_y: f32x4, max_iter: u32) -> u32x4 {
     count
 }
 
-#[cfg(any(target_feature = "avx", target_feature = "avx2"))]
+#[cfg(target_feature = "avx")]
 fn simd8(c_x: f32x8, c_y: f32x8, max_iter: u32) -> u32x8 {
     let mut x = c_x;
     let mut y = c_y;
@@ -63,7 +63,7 @@ fn simd8(c_x: f32x8, c_y: f32x8, max_iter: u32) -> u32x8 {
         let sum = xx + yy;
         let mask = sum.lt(f32x8::splat(4.0));
 
-        if !mask.all() { break }
+        if !mask.any() { break }
         count = count + mask.to_i().select(u32x8::splat(1), u32x8::splat(0));
 
         x = xx - yy + c_x;

--- a/benches/mandelbrot.rs
+++ b/benches/mandelbrot.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![feature(cfg_target_feature)]
 
 extern crate simd;
 extern crate test;
@@ -6,6 +7,8 @@ extern crate test;
 use test::black_box as bb;
 use test::Bencher as B;
 use simd::{f32x4, u32x4};
+#[cfg(any(target_feature = "avx", target_feature = "avx2"))]
+use simd::x86::avx::{f32x8, u32x8};
 
 fn naive(c_x: f32, c_y: f32, max_iter: u32) -> u32 {
     let mut x = c_x;
@@ -47,6 +50,28 @@ fn simd4(c_x: f32x4, c_y: f32x4, max_iter: u32) -> u32x4 {
     count
 }
 
+#[cfg(any(target_feature = "avx", target_feature = "avx2"))]
+fn simd8(c_x: f32x8, c_y: f32x8, max_iter: u32) -> u32x8 {
+    let mut x = c_x;
+    let mut y = c_y;
+
+    let mut count = u32x8::splat(0);
+    for _ in 0..max_iter as usize {
+        let xy = x * y;
+        let xx = x * x;
+        let yy = y * y;
+        let sum = xx + yy;
+        let mask = sum.lt(f32x8::splat(4.0));
+
+        if !mask.all() { break }
+        count = count + mask.to_i().select(u32x8::splat(1), u32x8::splat(0));
+
+        x = xx - yy + c_x;
+        y = xy + xy + c_y;
+    }
+    count
+}
+
 const SCALE: f32 = 3.0 / 100.0;
 const N: u32 = 100;
 #[bench]
@@ -71,6 +96,21 @@ fn mandel_simd4(b: &mut B) {
                 let i = u32x4::splat(i * 4) + tweak;
                 let x = f32x4::splat(-2.2) + f32x4::splat(SCALE) * i.to_f32();
                 bb(simd4(x, y, N));
+            }
+        }
+    })
+}
+#[cfg(any(target_feature = "avx", target_feature = "avx2"))]
+#[bench]
+fn mandel_simd8(b: &mut B) {
+    let tweak = u32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
+    b.iter(|| {
+        for j in 0..100 {
+            let y = f32x8::splat(-1.5) + f32x8::splat(SCALE) * u32x8::splat(j).to_f32();
+            for i in 0..13 { // 100 not divisible by 8 :(
+                let i = u32x8::splat(i * 8) + tweak;
+                let x = f32x8::splat(-2.2) + f32x8::splat(SCALE) * i.to_f32();
+                bb(simd8(x, y, N));
             }
         }
     })

--- a/benches/matrix.rs
+++ b/benches/matrix.rs
@@ -5,6 +5,7 @@ extern crate simd;
 use test::black_box as bb;
 use test::Bencher as B;
 use simd::f32x4;
+use simd::x86::avx::f64x4;
 
 
 #[bench]
@@ -37,7 +38,7 @@ fn multiply_naive(b: &mut B) {
 }
 
 #[bench]
-fn multiply_simd4(b: &mut B) {
+fn multiply_simd4_32(b: &mut B) {
     let x = [f32x4::splat(1.0_f32); 4];
     let y = [f32x4::splat(2.0); 4];
     b.iter(|| {
@@ -64,6 +65,39 @@ fn multiply_simd4(b: &mut B) {
              f32x4::splat(y3.extract(1)) * x[1] +
              f32x4::splat(y3.extract(2)) * x[2] +
              f32x4::splat(y3.extract(3)) * x[3],
+             ]);
+        }
+    })
+}
+
+#[bench]
+fn multiply_simd4_64(b: &mut B) {
+    let x = [f64x4::splat(1.0_f64); 4];
+    let y = [f64x4::splat(2.0); 4];
+    b.iter(|| {
+        for _ in 0..100 {
+        let (x, y) = bb((&x, &y));
+
+        let y0 = y[0];
+        let y1 = y[1];
+        let y2 = y[2];
+        let y3 = y[3];
+        bb(&[f64x4::splat(y0.extract(0)) * x[0] +
+             f64x4::splat(y0.extract(1)) * x[1] +
+             f64x4::splat(y0.extract(2)) * x[2] +
+             f64x4::splat(y0.extract(3)) * x[3],
+             f64x4::splat(y1.extract(0)) * x[0] +
+             f64x4::splat(y1.extract(1)) * x[1] +
+             f64x4::splat(y1.extract(2)) * x[2] +
+             f64x4::splat(y1.extract(3)) * x[3],
+             f64x4::splat(y2.extract(0)) * x[0] +
+             f64x4::splat(y2.extract(1)) * x[1] +
+             f64x4::splat(y2.extract(2)) * x[2] +
+             f64x4::splat(y2.extract(3)) * x[3],
+             f64x4::splat(y3.extract(0)) * x[0] +
+             f64x4::splat(y3.extract(1)) * x[1] +
+             f64x4::splat(y3.extract(2)) * x[2] +
+             f64x4::splat(y3.extract(3)) * x[3],
              ]);
         }
     })

--- a/benches/matrix.rs
+++ b/benches/matrix.rs
@@ -1,10 +1,12 @@
 #![feature(test)]
+#![feature(cfg_target_feature)]
 extern crate test;
 extern crate simd;
 
 use test::black_box as bb;
 use test::Bencher as B;
 use simd::f32x4;
+#[cfg(target_feature = "avx")]
 use simd::x86::avx::f64x4;
 
 
@@ -70,6 +72,7 @@ fn multiply_simd4_32(b: &mut B) {
     })
 }
 
+#[cfg(target_feature = "avx")]
 #[bench]
 fn multiply_simd4_64(b: &mut B) {
     let x = [f64x4::splat(1.0_f64); 4];

--- a/examples/axpy.rs
+++ b/examples/axpy.rs
@@ -39,7 +39,7 @@ pub fn axpy8(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
 
 
 #[cfg(not(target_feature = "avx"))]
-pub fn axpy8(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
+pub fn axpy8(_: &mut [f32], _: f32, _: &[f32], _: &[f32]) {
     unimplemented!()
 }
 

--- a/examples/axpy.rs
+++ b/examples/axpy.rs
@@ -1,0 +1,65 @@
+#![feature(cfg_target_feature)]
+extern crate simd;
+use simd::f32x4;
+#[cfg(target_feature = "avx")]
+use simd::x86::avx::f32x8;
+
+#[inline(never)]
+pub fn axpy(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
+    assert_eq!(x.len(), y.len());
+    assert_eq!(x.len(), z.len());
+
+    let len = std::cmp::min(std::cmp::min(x.len(), y.len()), z.len());
+
+    let mut i = 0;
+    while i < len & !3 {
+        let x = f32x4::load(x, i);
+        let y = f32x4::load(y, i);
+        (f32x4::splat(a) * x + y).store(z, i);
+        i += 4
+    }
+}
+
+#[cfg(target_feature = "avx")]
+#[inline(never)]
+pub fn axpy8(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
+    assert_eq!(x.len(), y.len());
+    assert_eq!(x.len(), z.len());
+
+    let len = std::cmp::min(std::cmp::min(x.len(), y.len()), z.len());
+
+    let mut i = 0;
+    while i < len & !7 {
+        let x = f32x8::load(x, i);
+        let y = f32x8::load(y, i);
+        (f32x8::splat(a) * x + y).store(z, i);
+        i += 8
+    }
+}
+
+
+#[cfg(not(target_feature = "avx"))]
+pub fn axpy8(x: &[f32], y: &[f32]) -> f32 {
+    unimplemented!()
+}
+
+
+fn main() {
+    let mut z = vec![0.; 4];
+    axpy(&mut z, 2., &[1.0, 3.0, 5.0, 7.0], &[2.0, 4.0, 6.0, 8.0]);
+    println!("{:?}", z);
+    let mut z = vec![0.; 8];
+    axpy(&mut z, 3., &[1.0, 3.0, 6.0, 7.0, 10.0, 6.0, 3.0, 2.0],
+                       &[2.0, 4.0, 6.0, 8.0, 2.0, 4.0, 6.0, 8.0]);
+    println!("{:?}", z);
+
+    if cfg!(target_feature = "avx") {
+        let mut z = vec![0.; 4];
+        axpy8(&mut z, 2., &[1.0, 3.0, 5.0, 7.0], &[2.0, 4.0, 6.0, 8.0]);
+        println!("{:?}", z);
+        let mut z = vec![0.; 8];
+        axpy8(&mut z, 3., &[1.0, 3.0, 6.0, 7.0, 10.0, 6.0, 3.0, 2.0],
+                           &[2.0, 4.0, 6.0, 8.0, 2.0, 4.0, 6.0, 8.0]);
+        println!("{:?}", z);
+    }
+}

--- a/examples/axpy.rs
+++ b/examples/axpy.rs
@@ -39,7 +39,7 @@ pub fn axpy8(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
 
 
 #[cfg(not(target_feature = "avx"))]
-pub fn axpy8(x: &[f32], y: &[f32]) -> f32 {
+pub fn axpy8(z: &mut [f32], a: f32, x: &[f32], y: &[f32]) {
     unimplemented!()
 }
 

--- a/examples/dot-product.rs
+++ b/examples/dot-product.rs
@@ -1,5 +1,8 @@
+#![feature(cfg_target_feature)]
 extern crate simd;
 use simd::f32x4;
+#[cfg(target_feature = "avx")]
+use simd::x86::avx::{f32x8, LowHigh128};
 
 #[inline(never)]
 pub fn dot(x: &[f32], y: &[f32]) -> f32 {
@@ -18,8 +21,40 @@ pub fn dot(x: &[f32], y: &[f32]) -> f32 {
     sum.extract(0) + sum.extract(1) + sum.extract(2) + sum.extract(3)
 }
 
+#[cfg(target_feature = "avx")]
+#[inline(never)]
+pub fn dot8(x: &[f32], y: &[f32]) -> f32 {
+    assert_eq!(x.len(), y.len());
+
+    let len = std::cmp::min(x.len(), y.len());
+
+    let mut sum = f32x8::splat(0.0);
+    let mut i = 0;
+    while i < len & !7 {
+        let x = f32x8::load(x, i);
+        let y = f32x8::load(y, i);
+        sum = sum + x * y;
+        i += 8
+    }
+    let sum = sum.low() + sum.high();
+    sum.extract(0) + sum.extract(1) + sum.extract(2) + sum.extract(3)
+}
+
+
+#[cfg(not(target_feature = "avx"))]
+pub fn dot8(x: &[f32], y: &[f32]) -> f32 {
+    unimplemented!()
+}
+
+
 fn main() {
     println!("{}", dot(&[1.0, 3.0, 5.0, 7.0], &[2.0, 4.0, 6.0, 8.0]));
     println!("{}", dot(&[1.0, 3.0, 6.0, 7.0, 10.0, 6.0, 3.0, 2.0],
                        &[2.0, 4.0, 6.0, 8.0, 2.0, 4.0, 6.0, 8.0]));
+
+    if cfg!(target_feature = "avx") {
+        println!("{}", dot8(&[1.0, 3.0, 5.0, 7.0], &[2.0, 4.0, 6.0, 8.0]));
+        println!("{}", dot8(&[1.0, 3.0, 6.0, 7.0, 10.0, 6.0, 3.0, 2.0],
+                           &[2.0, 4.0, 6.0, 8.0, 2.0, 4.0, 6.0, 8.0]));
+    }
 }

--- a/examples/dot-product.rs
+++ b/examples/dot-product.rs
@@ -42,7 +42,7 @@ pub fn dot8(x: &[f32], y: &[f32]) -> f32 {
 
 
 #[cfg(not(target_feature = "avx"))]
-pub fn dot8(x: &[f32], y: &[f32]) -> f32 {
+pub fn dot8(_: &[f32], _: &[f32]) -> f32 {
     unimplemented!()
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -161,12 +161,15 @@ macro_rules! bool_impls {
         [$(#[$cvt_meta: meta] $cvt: ident -> $cvt_to: ident),*];
         )*) => {
         $(impl $name {
+            /// Convert to integer representation.
             #[inline]
-            fn to_repr(self) -> $repr {
+            pub fn to_repr(self) -> $repr {
                 unsafe {mem::transmute(self)}
             }
+            /// Convert from integer representation.
             #[inline]
-            fn from_repr(x: $repr) -> Self {
+            #[inline]
+            pub fn from_repr(x: $repr) -> Self {
                 unsafe {mem::transmute(x)}
             }
 

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -3,14 +3,14 @@ use std::mem;
 #[allow(unused_imports)]
 use super::{
 	Simd,
-    f32x2,
+    u32x4, i32x4, u16x8, i16x8, u8x16, i8x16, f32x4,
+    bool32ix4, bool16ix8, bool8ix16, bool32fx4,
     simd_eq, simd_ne, simd_lt, simd_le, simd_gt, simd_ge,
     simd_shuffle2, simd_shuffle4, simd_shuffle8, simd_shuffle16,
     simd_insert, simd_extract,
     simd_cast,
     simd_add, simd_sub, simd_mul, simd_div, simd_shl, simd_shr, simd_and, simd_or, simd_xor,
     bool8i, bool16i, bool32i, bool32f,
-    i16x8, u16x8,
     Unalign, bitcast,
 };
 use super::sixty_four::*;
@@ -123,52 +123,41 @@ basic_impls! {
     u16x16: u16, bool16ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
     i16x16: i16, bool16ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
 
-    // u8x16: u8, bool8ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
-    // i8x16: i8, bool8ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
+    u8x32: u8, bool8ix32, simd_shuffle32, 32, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 |
+        x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31;
+    i8x32: i8, bool8ix32, simd_shuffle32, 32, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 |
+        x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31;
 }
 
 #[cfg(all(not(target_feature = "avx")))]
 #[doc(hidden)]
 mod common {
     use super::*;
-    // naive implementations for now;
-    // this could be improved by treating lower and upper halfs as SSE vectors
-    #[inline]
-    pub fn bool64ix4_all(x: bool64ix4) -> bool {
-        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0
+    // implementation via SSE vectors
+    macro_rules! bools {
+        ($($ty: ty, $all: ident, $any: ident;)*) => {
+            $(
+                #[inline]
+                pub fn $all(x: $ty) -> bool {
+                    x.low().all() && x.high().all()
+                }
+                #[inline]
+                pub fn $any(x: $ty) -> bool {
+                    x.low().any() || x.high().any()
+                }
+                )*
+        }
     }
-    #[inline]
-    pub fn bool64ix4_any(x: bool64ix4) -> bool {
-        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0
+
+    bools! {
+        bool64ix4, bool64ix4_all, bool64ix4_any;
+        bool64fx4, bool64fx4_all, bool64fx4_any;
+        bool32ix8, bool32ix8_all, bool32ix8_any;
+        bool32fx8, bool32fx8_all, bool32fx8_any;
+        bool16ix16, bool16ix16_all, bool16ix16_any;
+        bool8ix32, bool8ix32_all, bool8ix32_any;
     }
-    #[inline]
-    pub fn bool64fx4_all(x: bool64fx4) -> bool {
-        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0
-    }
-    #[inline]
-    pub fn bool64fx4_any(x: bool64fx4) -> bool {
-        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0
-    }
-    #[inline]
-    pub fn bool32ix8_all(x: bool32ix8) -> bool {
-        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0 &&
-        x.4 != 0 && x.5 != 0 && x.6 != 0 && x.7 != 0
-    }
-    #[inline]
-    pub fn bool32ix8_any(x: bool32ix8) -> bool {
-        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0 ||
-        x.4 != 0 || x.5 != 0 || x.6 != 0 || x.7 != 0
-    }
-    #[inline]
-    pub fn bool32fx8_all(x: bool32fx8) -> bool {
-        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0 &&
-        x.4 != 0 && x.5 != 0 && x.6 != 0 && x.7 != 0
-    }
-    #[inline]
-    pub fn bool32fx8_any(x: bool32fx8) -> bool {
-        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0 ||
-        x.4 != 0 || x.5 != 0 || x.6 != 0 || x.7 != 0
-    }
+
 }
 
 bool_impls! {
@@ -179,6 +168,7 @@ bool_impls! {
     bool64fx4: bool64f, i64x4, i64, 4, bool64fx4_all, bool64fx4_any, x0, x1 | x2, x3
         [/// Convert `self` to a boolean vector for interacting with integer vectors.
          to_i -> bool64ix4];
+
     bool32ix8: bool32i, i32x8, i32, 8, bool32ix8_all, bool32ix8_any, x0, x1, x2, x3 | x4, x5, x6, x7
         [/// Convert `self` to a boolean vector for interacting with floating point vectors.
          to_f -> bool32fx8];
@@ -186,6 +176,130 @@ bool_impls! {
     bool32fx8: bool32f, i32x8, i32, 8, bool32fx8_all, bool32fx8_any, x0, x1, x2, x3 | x4, x5, x6, x7
         [/// Convert `self` to a boolean vector for interacting with integer vectors.
          to_i -> bool32ix8];
+
+    bool16ix16: bool16i, i16x16, i16, 16, bool16ix16_all, bool16ix16_any,
+            x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15 [];
+
+    bool8ix32: bool8i, i8x32, i8, 32, bool8ix32_all, bool8ix32_any,
+        x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 |
+        x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31 [];
+}
+
+pub trait LowHigh128 {
+    type Half: Simd;
+    /// Extract the low 128 bit part.
+    fn low(self) -> Self::Half;
+    /// Extract the high 128 bit part.
+    fn high(self) -> Self::Half;
+}
+
+macro_rules! expr { ($x:expr) => ($x) } // HACK
+macro_rules! low_high_impls {
+    ($(
+        $name: ident, $half: ident, $($first: tt),+ ... $($last: tt),+;
+        )*) => {
+        $(impl LowHigh128 for $name {
+            type Half = $half;
+            #[inline]
+            fn low(self) -> Self::Half {
+                $half::new($( expr!(self.$first), )*)
+            }
+
+            #[inline]
+            fn high(self) -> Self::Half {
+                $half::new($( expr!(self.$last), )*)
+            }
+        })*
+    }
+}
+
+low_high_impls! {
+    u64x4, u64x2, 0, 1 ... 2, 3;
+    i64x4, i64x2, 0, 1 ... 2, 3;
+    f64x4, f64x2, 0, 1 ... 2, 3;
+
+    u32x8, u32x4, 0, 1, 2, 3 ... 4, 5, 6, 7;
+    i32x8, i32x4, 0, 1, 2, 3 ... 4, 5, 6, 7;
+    f32x8, f32x4, 0, 1, 2, 3 ... 4, 5, 6, 7;
+
+    u16x16, u16x8, 0, 1, 2, 3, 4, 5, 6, 7 ... 8, 9, 10, 11, 12, 13, 14, 15;
+    i16x16, i16x8, 0, 1, 2, 3, 4, 5, 6, 7 ... 8, 9, 10, 11, 12, 13, 14, 15;
+
+    u8x32, u8x16,  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ...
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31;
+    i8x32, i8x16,  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ...
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31;
+
+}
+
+macro_rules! bool_low_high_impls {
+    ($(
+        $name: ident: $half: ident;
+        )*) => {
+        $(impl LowHigh128 for $name {
+            type Half = $half;
+            /// Extract the low 128 bit part.
+            #[inline]
+            fn low(self) -> Self::Half {
+                Self::Half::from_repr(self.to_repr().low())
+            }
+
+            /// Extract the high 128 bit part.
+            #[inline]
+            fn high(self) -> Self::Half {
+                Self::Half::from_repr(self.to_repr().high())
+            }
+        })*
+    }
+}
+
+bool_low_high_impls! {
+    bool64fx4: bool64fx2;
+    bool32fx8: bool32fx4;
+
+    bool64ix4: bool64ix2;
+    bool32ix8: bool32ix4;
+    bool16ix16: bool16ix8;
+    bool8ix32: bool8ix16;
+}
+
+impl u64x4 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i64(self) -> i64x4 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to a 64-bit float.
+    #[inline]
+    pub fn to_f64(self) -> f64x4 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl i64x4 {
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u64(self) -> u64x4 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to a 64-bit float.
+    #[inline]
+    pub fn to_f64(self) -> f64x4 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl f64x4 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i64(self) -> i64x4 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u64(self) -> u64x4 {
+        unsafe {simd_cast(self)}
+    }
 }
 
 impl u32x8 {
@@ -200,6 +314,7 @@ impl u32x8 {
         unsafe {simd_cast(self)}
     }
 }
+
 impl i32x8 {
     /// Convert each lane to an unsigned integer.
     #[inline]
@@ -209,6 +324,38 @@ impl i32x8 {
     /// Convert each lane to a 32-bit float.
     #[inline]
     pub fn to_f32(self) -> f32x8 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl i16x16 {
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u16(self) -> u16x16 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl u16x16 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i16(self) -> i16x16 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl i8x32 {
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u8(self) -> u8x32 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+impl u8x32 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i8(self) -> i8x32 {
         unsafe {simd_cast(self)}
     }
 }
@@ -226,16 +373,51 @@ operators! {
     Div (simd_div, div): f64x4, f32x8;
 
     BitAnd (simd_and, bitand):
-        i64x4, u64x4, i32x8, u32x8,
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
         bool64ix4, bool32ix8, bool16ix16,
         bool64fx4, bool32fx8;
     BitOr (simd_or, bitor):
-        i64x4, u64x4, i32x8, u32x8,
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
         bool64ix4, bool32ix8, bool16ix16,
         bool64fx4, bool32fx8;
     BitXor (simd_xor, bitxor):
-        i64x4, u64x4, i32x8, u32x8,
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
         bool64ix4, bool32ix8, bool16ix16,
         bool64fx4, bool32fx8;
 }
 
+neg_impls!{
+    0,
+    i64x4,
+    i32x8,
+    i16x16,
+    i8x32,
+}
+
+neg_impls! {
+    0.0,
+    f64x4,
+    f32x8,
+}
+
+not_impls! {
+    i64x4,
+    u64x4,
+    i32x8,
+    u32x8,
+    i16x16,
+    u16x16,
+    i8x32,
+    u8x32,
+}
+
+shift! {
+    i64x4,
+    u64x4,
+    i32x8,
+    u32x8,
+    i16x16,
+    u16x16,
+    i8x32,
+    u8x32
+}

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -8,7 +8,7 @@ use super::{
     simd_insert, simd_extract,
     simd_cast,
     simd_add, simd_sub, simd_mul, simd_div, simd_shl, simd_shr, simd_and, simd_or, simd_xor,
-
+    bool32f,
     Unalign, bitcast,
 };
 use super::sixty_four::*;
@@ -45,7 +45,7 @@ pub struct i32x8(i32, i32, i32, i32,
                  i32, i32, i32, i32);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derfve(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct f32x8(f32, f32, f32, f32,
                  f32, f32, f32, f32);
 #[repr(simd)]
@@ -54,7 +54,7 @@ pub struct f32x8(f32, f32, f32, f32,
 pub struct bool32ix8(i32, i32, i32, i32,
                      i32, i32, i32, i32);#[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool32fx8(i32, i32, i32, i32,
                      i32, i32, i32, i32);
 
@@ -98,17 +98,19 @@ pub struct bool8ix32(i8, i8, i8, i8, i8, i8, i8, i8,
 					 
 operators! {
     Add (simd_add, add):
-        f64x4;
+        f64x4, f32x8;
     Sub (simd_sub, sub):
-        f64x4;
+        f64x4, f32x8;
     Mul (simd_mul, mul):
-        f64x4;
-    Div (simd_div, div): f64x4;
+        f64x4, f32x8;
+    Div (simd_div, div): f64x4, f32x8;
 }
 
 simd! {
     bool64fx4: f64x4 = f64, bool64fx4 = bool64f;
+    bool32fx8: f32x8 = f32, bool32fx8 = bool32f;
 }
 basic_impls! {
     f64x4: f64, bool64fx4, simd_shuffle4, 4, x0, x1 | x2, x3;
+    f32x8: f32, bool32fx8, simd_shuffle8, 8, x0, x1, x2, x3 | x4, x5, x6, x7;
 }

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -1,3 +1,17 @@
+use std::ops;
+#[allow(unused_imports)]
+use super::{
+	Simd,
+    f32x2,
+    simd_eq, simd_ne, simd_lt, simd_le, simd_gt, simd_ge,
+    simd_shuffle2, simd_shuffle4, simd_shuffle8, simd_shuffle16,
+    simd_insert, simd_extract,
+    simd_cast,
+    simd_add, simd_sub, simd_mul, simd_div, simd_shl, simd_shr, simd_and, simd_or, simd_xor,
+
+    Unalign, bitcast,
+};
+use super::sixty_four::*;
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
@@ -8,7 +22,7 @@ pub struct u64x4(u64, u64, u64, u64);
 pub struct i64x4(i64, i64, i64, i64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct f64x4(f64, f64, f64, f64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -16,7 +30,7 @@ pub struct f64x4(f64, f64, f64, f64);
 pub struct bool64ix4(i64, i64, i64, i64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool64fx4(i64, i64, i64, i64);
 
 #[repr(simd)]
@@ -81,3 +95,20 @@ pub struct bool8ix32(i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8);
+					 
+operators! {
+    Add (simd_add, add):
+        f64x4;
+    Sub (simd_sub, sub):
+        f64x4;
+    Mul (simd_mul, mul):
+        f64x4;
+    Div (simd_div, div): f64x4;
+}
+
+simd! {
+    bool64fx4: f64x4 = f64, bool64fx4 = bool64f;
+}
+basic_impls! {
+    f64x4: f64, bool64fx4, simd_shuffle4, 4, x0, x1 | x2, x3;
+}

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -1,4 +1,5 @@
 use std::ops;
+use std::mem;
 #[allow(unused_imports)]
 use super::{
 	Simd,
@@ -8,17 +9,21 @@ use super::{
     simd_insert, simd_extract,
     simd_cast,
     simd_add, simd_sub, simd_mul, simd_div, simd_shl, simd_shr, simd_and, simd_or, simd_xor,
-    bool32f,
+    bool8i, bool16i, bool32i, bool32f,
+    i16x8, u16x8,
     Unalign, bitcast,
 };
 use super::sixty_four::*;
+#[cfg(all(target_feature = "avx"))]
+use super::x86::avx::common;
+
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct u64x4(u64, u64, u64, u64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct i64x4(i64, i64, i64, i64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -26,7 +31,7 @@ pub struct i64x4(i64, i64, i64, i64);
 pub struct f64x4(f64, f64, f64, f64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool64ix4(i64, i64, i64, i64);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -35,12 +40,12 @@ pub struct bool64fx4(i64, i64, i64, i64);
 
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct u32x8(u32, u32, u32, u32,
                  u32, u32, u32, u32);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct i32x8(i32, i32, i32, i32,
                  i32, i32, i32, i32);
 #[repr(simd)]
@@ -50,7 +55,7 @@ pub struct f32x8(f32, f32, f32, f32,
                  f32, f32, f32, f32);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool32ix8(i32, i32, i32, i32,
                      i32, i32, i32, i32);#[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -60,57 +65,177 @@ pub struct bool32fx8(i32, i32, i32, i32,
 
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct u16x16(u16, u16, u16, u16, u16, u16, u16, u16,
                   u16, u16, u16, u16, u16, u16, u16, u16);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct i16x16(i16, i16, i16, i16, i16, i16, i16, i16,
                   i16, i16, i16, i16, i16, i16, i16, i16);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool16ix16(i16, i16, i16, i16, i16, i16, i16, i16,
                       i16, i16, i16, i16, i16, i16, i16, i16);
 
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct u8x32(u8, u8, u8, u8, u8, u8, u8, u8,
                  u8, u8, u8, u8, u8, u8, u8, u8,
                  u8, u8, u8, u8, u8, u8, u8, u8,
                  u8, u8, u8, u8, u8, u8, u8, u8);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct i8x32(i8, i8, i8, i8, i8, i8, i8, i8,
                  i8, i8, i8, i8, i8, i8, i8, i8,
                  i8, i8, i8, i8, i8, i8, i8, i8,
                  i8, i8, i8, i8, i8, i8, i8, i8);
 #[repr(simd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy)]
 pub struct bool8ix32(i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8,
                      i8, i8, i8, i8, i8, i8, i8, i8);
-					 
-operators! {
-    Add (simd_add, add):
-        f64x4, f32x8;
-    Sub (simd_sub, sub):
-        f64x4, f32x8;
-    Mul (simd_mul, mul):
-        f64x4, f32x8;
-    Div (simd_div, div): f64x4, f32x8;
-}
 
 simd! {
-    bool64fx4: f64x4 = f64, bool64fx4 = bool64f;
+    bool8ix32: i8x32 = i8, u8x32 = u8, bool8ix32 = bool8i;
+    bool16ix16: i16x16 = i16, u16x16 = u16, bool16ix16 = bool16i;
+    bool32ix8: i32x8 = i32, u32x8 = u32, bool32ix8 = bool32i;
+    bool64ix4: i64x4 = i64, u64x4 = u64, bool64ix4 = bool64i;
+
     bool32fx8: f32x8 = f32, bool32fx8 = bool32f;
+    bool64fx4: f64x4 = f64, bool64fx4 = bool64f;
 }
+
 basic_impls! {
+    u64x4: u64, bool64ix4, simd_shuffle4, 4, x0, x1 | x2, x3;
+    i64x4: i64, bool64ix4, simd_shuffle4, 4, x0, x1 | x2, x3;
     f64x4: f64, bool64fx4, simd_shuffle4, 4, x0, x1 | x2, x3;
+
+    u32x8: u32, bool32ix8, simd_shuffle8, 8, x0, x1, x2, x3 | x4, x5, x6, x7;
+    i32x8: i32, bool32ix8, simd_shuffle8, 8, x0, x1, x2, x3 | x4, x5, x6, x7;
     f32x8: f32, bool32fx8, simd_shuffle8, 8, x0, x1, x2, x3 | x4, x5, x6, x7;
+
+    u16x16: u16, bool16ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
+    i16x16: i16, bool16ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
+
+    // u8x16: u8, bool8ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
+    // i8x16: i8, bool8ix16, simd_shuffle16, 16, x0, x1, x2, x3, x4, x5, x6, x7 | x8, x9, x10, x11, x12, x13, x14, x15;
 }
+
+#[cfg(all(not(target_feature = "avx")))]
+#[doc(hidden)]
+mod common {
+    use super::*;
+    // naive implementations for now;
+    // this could be improved by treating lower and upper halfs as SSE vectors
+    #[inline]
+    pub fn bool64ix4_all(x: bool64ix4) -> bool {
+        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0
+    }
+    #[inline]
+    pub fn bool64ix4_any(x: bool64ix4) -> bool {
+        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0
+    }
+    #[inline]
+    pub fn bool64fx4_all(x: bool64fx4) -> bool {
+        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0
+    }
+    #[inline]
+    pub fn bool64fx4_any(x: bool64fx4) -> bool {
+        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0
+    }
+    #[inline]
+    pub fn bool32ix8_all(x: bool32ix8) -> bool {
+        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0 &&
+        x.4 != 0 && x.5 != 0 && x.6 != 0 && x.7 != 0
+    }
+    #[inline]
+    pub fn bool32ix8_any(x: bool32ix8) -> bool {
+        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0 ||
+        x.4 != 0 || x.5 != 0 || x.6 != 0 || x.7 != 0
+    }
+    #[inline]
+    pub fn bool32fx8_all(x: bool32fx8) -> bool {
+        x.0 != 0 && x.1 != 0 && x.2 != 0 && x.3 != 0 &&
+        x.4 != 0 && x.5 != 0 && x.6 != 0 && x.7 != 0
+    }
+    #[inline]
+    pub fn bool32fx8_any(x: bool32fx8) -> bool {
+        x.0 != 0 || x.1 != 0 || x.2 != 0 || x.3 != 0 ||
+        x.4 != 0 || x.5 != 0 || x.6 != 0 || x.7 != 0
+    }
+}
+
+bool_impls! {
+    bool64ix4: bool64i, i64x4, i64, 4, bool64ix4_all, bool64ix4_any, x0, x1 | x2, x3
+        [/// Convert `self` to a boolean vector for interacting with floating point vectors.
+         to_f -> bool64fx4];
+
+    bool64fx4: bool64f, i64x4, i64, 4, bool64fx4_all, bool64fx4_any, x0, x1 | x2, x3
+        [/// Convert `self` to a boolean vector for interacting with integer vectors.
+         to_i -> bool64ix4];
+    bool32ix8: bool32i, i32x8, i32, 8, bool32ix8_all, bool32ix8_any, x0, x1, x2, x3 | x4, x5, x6, x7
+        [/// Convert `self` to a boolean vector for interacting with floating point vectors.
+         to_f -> bool32fx8];
+
+    bool32fx8: bool32f, i32x8, i32, 8, bool32fx8_all, bool32fx8_any, x0, x1, x2, x3 | x4, x5, x6, x7
+        [/// Convert `self` to a boolean vector for interacting with integer vectors.
+         to_i -> bool32ix8];
+}
+
+impl u32x8 {
+    /// Convert each lane to a signed integer.
+    #[inline]
+    pub fn to_i32(self) -> i32x8 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to a 32-bit float.
+    #[inline]
+    pub fn to_f32(self) -> f32x8 {
+        unsafe {simd_cast(self)}
+    }
+}
+impl i32x8 {
+    /// Convert each lane to an unsigned integer.
+    #[inline]
+    pub fn to_u32(self) -> u32x8 {
+        unsafe {simd_cast(self)}
+    }
+    /// Convert each lane to a 32-bit float.
+    #[inline]
+    pub fn to_f32(self) -> f32x8 {
+        unsafe {simd_cast(self)}
+    }
+}
+
+operators! {
+    Add (simd_add, add):
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
+        f64x4, f32x8;
+    Sub (simd_sub, sub):
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
+        f64x4, f32x8;
+    Mul (simd_mul, mul):
+        i8x32, u8x32, i16x16, u16x16, i32x8, u32x8, i64x4, u64x4,
+        f64x4, f32x8;
+    Div (simd_div, div): f64x4, f32x8;
+
+    BitAnd (simd_and, bitand):
+        i64x4, u64x4, i32x8, u32x8,
+        bool64ix4, bool32ix8, bool16ix16,
+        bool64fx4, bool32fx8;
+    BitOr (simd_or, bitor):
+        i64x4, u64x4, i32x8, u32x8,
+        bool64ix4, bool32ix8, bool16ix16,
+        bool64fx4, bool32fx8;
+    BitXor (simd_xor, bitxor):
+        i64x4, u64x4, i32x8, u32x8,
+        bool64ix4, bool32ix8, bool16ix16,
+        bool64fx4, bool32fx8;
+}
+

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::ops;
 use std::mem;
 #[allow(unused_imports)]

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -48,6 +48,39 @@ extern "platform-intrinsic" {
     fn x86_mm256_testz_si256(x: u64x4, y: u64x4) -> i32;
 }
 
+#[doc(hidden)]
+pub mod common {
+    use super::*;
+    use super::super::super::*;
+    use std::mem;
+
+    macro_rules! bools {
+        ($($ty: ty, $all: ident, $any: ident, $testc: ident, $testz: ident;)*) => {
+            $(
+                #[inline]
+                pub fn $all(x: $ty) -> bool {
+                    unsafe {
+                        super::$testc(mem::transmute(x), mem::transmute(<$ty>::splat(true))) != 0
+                    }
+                }
+                #[inline]
+                pub fn $any(x: $ty) -> bool {
+                    unsafe {
+                        super::$testz(mem::transmute(x), mem::transmute(x)) == 0
+                    }
+                }
+                )*
+        }
+    }
+
+    bools! {
+        bool32fx8, bool32fx8_all, bool32fx8_any, x86_mm256_testc_ps, x86_mm256_testz_ps;
+        bool32ix8, bool32ix8_all, bool32ix8_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
+        bool64fx4, bool64fx4_all, bool64fx4_any, x86_mm256_testc_pd, x86_mm256_testz_pd;
+        bool64ix4, bool64ix4_all, bool64ix4_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
+    }
+}
+
 // 128-bit vectors:
 
 // 32 bit floats

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -61,13 +61,26 @@ impl AvxF32x4 for f32x4 {
     }
 }
 
-pub trait Sse3F64x4 {
+pub trait AvxF64x4 {
+    fn sqrt(self) -> Self;
     fn addsub(self, other: Self) -> Self;
     fn hadd(self, other: Self) -> Self;
     fn hsub(self, other: Self) -> Self;
 }
 
-impl Sse3F64x4 for f64x4 {
+pub trait AvxF32x8 {
+    fn sqrt(self) -> Self;
+    fn addsub(self, other: Self) -> Self;
+    fn hadd(self, other: Self) -> Self;
+    fn hsub(self, other: Self) -> Self;
+}
+
+impl AvxF64x4 for f64x4 {
+    #[inline]
+    fn sqrt(self) -> Self {
+        unsafe { x86_mm256_sqrt_pd(self) }
+    }
+
     #[inline]
     fn addsub(self, other: Self) -> Self {
         unsafe { x86_mm256_addsub_pd(self, other) }
@@ -81,6 +94,28 @@ impl Sse3F64x4 for f64x4 {
     #[inline]
     fn hsub(self, other: Self) -> Self {
         unsafe { x86_mm256_hsub_pd(self, other) }
+    }
+}
+
+impl AvxF32x8 for f32x8 {
+    #[inline]
+    fn sqrt(self) -> Self {
+        unsafe { x86_mm256_sqrt_ps(self) }
+    }
+
+    #[inline]
+    fn addsub(self, other: Self) -> Self {
+        unsafe { x86_mm256_addsub_ps(self, other) }
+    }
+
+    #[inline]
+    fn hadd(self, other: Self) -> Self {
+        unsafe { x86_mm256_hadd_ps(self, other) }
+    }
+
+    #[inline]
+    fn hsub(self, other: Self) -> Self {
+        unsafe { x86_mm256_hsub_ps(self, other) }
     }
 }
 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -6,6 +6,7 @@ pub use v256::{
     f32x8, bool32fx8, u32x8, i32x8, bool32ix8,
     u16x16, i16x16, bool16ix16,
     u8x32, i8x32, bool8ix32,
+    LowHigh128
 };
 
 #[allow(dead_code)]

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -61,6 +61,29 @@ impl AvxF32x4 for f32x4 {
     }
 }
 
+pub trait Sse3F64x4 {
+    fn addsub(self, other: Self) -> Self;
+    fn hadd(self, other: Self) -> Self;
+    fn hsub(self, other: Self) -> Self;
+}
+
+impl Sse3F64x4 for f64x4 {
+    #[inline]
+    fn addsub(self, other: Self) -> Self {
+        unsafe { x86_mm256_addsub_pd(self, other) }
+    }
+
+    #[inline]
+    fn hadd(self, other: Self) -> Self {
+        unsafe { x86_mm256_hadd_pd(self, other) }
+    }
+
+    #[inline]
+    fn hsub(self, other: Self) -> Self {
+        unsafe { x86_mm256_hsub_pd(self, other) }
+    }
+}
+
 pub trait AvxBool32fx4 {}
 impl AvxBool32fx4 for bool32fx4 {}
 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -51,7 +51,6 @@ extern "platform-intrinsic" {
 #[doc(hidden)]
 pub mod common {
     use super::*;
-    use super::super::super::*;
     use std::mem;
 
     macro_rules! bools {
@@ -75,8 +74,10 @@ pub mod common {
 
     bools! {
         bool32fx8, bool32fx8_all, bool32fx8_any, x86_mm256_testc_ps, x86_mm256_testz_ps;
-        bool32ix8, bool32ix8_all, bool32ix8_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
         bool64fx4, bool64fx4_all, bool64fx4_any, x86_mm256_testc_pd, x86_mm256_testz_pd;
+        bool8ix32, bool8ix32_all, bool8ix32_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
+        bool16ix16, bool16ix16_all, bool16ix16_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
+        bool32ix8, bool32ix8_all, bool32ix8_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
         bool64ix4, bool64ix4_all, bool64ix4_any, x86_mm256_testc_si256, x86_mm256_testz_si256;
     }
 }

--- a/src/x86/avx2.rs
+++ b/src/x86/avx2.rs
@@ -52,3 +52,14 @@ extern "platform-intrinsic" {
     fn x86_mm256_subs_epi16(x: i16x16, y: i16x16) -> i16x16;
     fn x86_mm256_subs_epu16(x: u16x16, y: u16x16) -> u16x16;
 }
+
+// broken on rustc 1.7.0-nightly (1ddaf8bdf 2015-12-12)
+// pub trait Avx2F32x8 {
+//     fn permutevar(self, other: i32x8) -> f32x8;
+// }
+//
+// impl Avx2F32x8 for f32x8 {
+//     fn permutevar(self, other: i32x8) -> f32x8 {
+//         unsafe { x86_mm256_permutevar8x32_ps(self, other) }
+//     }
+// }


### PR DESCRIPTION
This pull request implements all of the basic operations on 256-bit vectors and some AVX specific functions, building on the original work by @liebharc.
Resolves #17 .

It also adds a few examples and benchmarks. Mandelbrot and matrix transpose benchmarks on my MacBook pro with i5 Haswell:

```
test mandel_naive ... bench:     710,853 ns/iter (+/- 187,256)
test mandel_simd4 ... bench:     220,815 ns/iter (+/- 101,636)
test mandel_simd8 ... bench:     115,457 ns/iter (+/- 36,033)
...
test transpose_naive              ... bench:         762 ns/iter (+/- 313)
test transpose_simd4              ... bench:         261 ns/iter (+/- 84)
test transpose_simd8_avx2_vpermpd ... bench:         154 ns/iter (+/- 48)
test transpose_simd8_avx2_vpermps ... bench:         151 ns/iter (+/- 77)
```

By the way, when implementing the 256-bit bool operations, it is useful to have public `to_repr` and `from_repr` on bools, so I have changed the visibility. I think this is also handy in applications as well.

I welcome any comments. It would be great if this functionality was merged.
